### PR TITLE
Fix cookie expiration duration

### DIFF
--- a/src/Preview.js
+++ b/src/Preview.js
@@ -5,7 +5,7 @@ import qs from 'qs';
 import Prismic from 'prismic-javascript';
 import PrismicConfig from './prismic-configuration';
 
-const PREVIEW_EXPIRES = 30 * 60 * 1000; // 30 minutes
+const PREVIEW_EXPIRES = 1/48; // 30 minutes
 
 export default class Preview extends React.Component {
 


### PR DESCRIPTION
The cookie is set in days, not milliseconds. So the original code was setting the cookie to expire in about 5000 years. I fixed it to actually expire in 30 minutes.